### PR TITLE
Documentation.jsx - use camel-case autoFill

### DIFF
--- a/src/pages/Documentation/Documentation.jsx
+++ b/src/pages/Documentation/Documentation.jsx
@@ -16,7 +16,7 @@ const marqueeProps = {
     defaultValue: '""',
     required: false
   },
-  autofill: {
+  autoFill: {
     description: "Whether to automatically fill blank space in the marquee with copies of the children or not.",
     type: "boolean",
     defaultValue: "false",


### PR DESCRIPTION
Hey :wave: 

got confused a bit when "autofill" didn't work for me until I noticed in github repo it's "autoFill" (or at least that one worked).

Great module by the way :raised_hands: thank you very much for it, saved me lots of css-headache